### PR TITLE
Implement logging support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,6 +807,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +934,7 @@ dependencies = [
  "inquire",
  "serde",
  "serde_json",
+ "serde_repr",
  "tokio",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ dashmap = "5.5.3"
 inquire = "0.7.4"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.116"
+serde_repr = "0.1.19"
 tokio = { version = "1.36.0", features = ["full"] }
 toml = "0.8.12"
 

--- a/src/api/logs.rs
+++ b/src/api/logs.rs
@@ -13,18 +13,6 @@ enum MessageType {
     Error = 3,
 }
 
-impl From<u8> for MessageType {
-    fn from(value: u8) -> Self {
-        match value {
-            0 => MessageType::Output,
-            1 => MessageType::Info,
-            2 => MessageType::Warning,
-            3 => MessageType::Error,
-            _ => MessageType::Output,
-        }
-    }
-}
-
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 struct Log {

--- a/src/api/logs.rs
+++ b/src/api/logs.rs
@@ -1,9 +1,51 @@
 use axum::{http::StatusCode, Json};
+use console::style;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use serde_repr::{Deserialize_repr, Serialize_repr};
 
-// Not implemented yet
+#[derive(Serialize_repr, Deserialize_repr, Debug)]
+#[repr(u8)]
+enum MessageType {
+    Output = 0,
+    Info = 1,
+    Warning = 2,
+    Error = 3,
+}
+
+impl From<u8> for MessageType {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => MessageType::Output,
+            1 => MessageType::Info,
+            2 => MessageType::Warning,
+            3 => MessageType::Error,
+            _ => MessageType::Output,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct Log {
+    message: String,
+    message_type: MessageType,
+}
+
 pub async fn logs(Json(body): Json<Value>) -> StatusCode {
-    println!("{}", body);
+    let log: Log = serde_json::from_value(body).unwrap();
+
+    match log.message_type {
+        MessageType::Output | MessageType::Info => {
+            println!("Output: {}", log.message);
+        }
+        MessageType::Warning => {
+            println!("Warning: {}", style(log.message).yellow());
+        }
+        MessageType::Error => {
+            println!("Error: {}", style(log.message).red());
+        }
+    }
 
     StatusCode::OK
 }


### PR DESCRIPTION
Listens on the `/logs` endpoint and outputs them in the terminal.
Closes #2
